### PR TITLE
fix the typo in log of completed task

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ const logFinished = (isSilent, taskName) => {
   if (!isSilent) {
     console.log(
       color.greenBright(color.symbols.check),
-      `${color.dim("started:")}${taskName}`
+      `${color.dim("completed:")}${taskName}`
     );
   }
 };


### PR DESCRIPTION
Earlier it was like this
![Kazam_screenshot_00018](https://user-images.githubusercontent.com/31199288/84431843-9de76880-ac49-11ea-8dd6-b819f75c0e9e.png)
Now I have fixed it and it is like below.
![Kazam_screenshot_00019](https://user-images.githubusercontent.com/31199288/84431888-af307500-ac49-11ea-9409-3d7a5fa6881b.png)
Please accept the PR if it is fine.